### PR TITLE
Missing .to_s.classify in where() in some methods

### DIFF
--- a/lib/recommendable/acts_as_recommended_to.rb
+++ b/lib/recommendable/acts_as_recommended_to.rb
@@ -122,7 +122,7 @@ module Recommendable
       # @param [Class, String, Symbol] klass the class of records. Can be the class constant, or a String/Symbol representation of the class name.
       # @return [Array] an array of ActiveRecord objects that self has liked belonging to klass
       def liked_for klass
-        likes.where(:likeable_type => klass).includes(:likeable).map(&:likeable)
+        likes.where(:likeable_type => klass.to_s.classify).includes(:likeable).map(&:likeable)
       end
 
       # Get a list of Recommendable::Likes with a `#likeable_type` of the passed
@@ -190,7 +190,7 @@ module Recommendable
       # @param [Class, String, Symbol] klass the class of records. Can be the class constant, or a String/Symbol representation of the class name.
       # @return [Array] an array of ActiveRecord objects that self has disliked belonging to klass
       def disliked_for klass
-        dislikes.where(:dislikeable_type => klass).includes(:dislikeable).map(&:dislikeable)
+        dislikes.where(:dislikeable_type => klass.to_s.classify).includes(:dislikeable).map(&:dislikeable)
       end
       
       # Get a list of Recommendable::Dislikes with a `#dislikeable_type` of the
@@ -253,7 +253,7 @@ module Recommendable
       # @param [Class, String, Symbol] klass the class of records. Can be the class constant, or a String/Symbol representation of the class name.
       # @return [Array] an array of ActiveRecord objects that self has stashed belonging to klass
       def stashed_for klass
-        stashed_items.where(:stashable_type => klass).includes(:stashable).map(&:stashable)
+        stashed_items.where(:stashable_type => klass.to_s.classify).includes(:stashable).map(&:stashable)
       end
     end
     
@@ -305,7 +305,7 @@ module Recommendable
       # @param [Class, String, Symbol] klass the class of records. Can be the class constant, or a String/Symbol representation of the class name.
       # @return [Array] an array of ActiveRecord objects that self has ignored belonging to klass
       def ignored_for klass
-        ignores.where(:ignoreable_type => klass).includes(:ignoreable).map(&:ignoreable)
+        ignores.where(:ignoreable_type => klass.to_s.classify).includes(:ignoreable).map(&:ignoreable)
       end
     end
     


### PR DESCRIPTION
Hi there,

I'm not very familiar with pull requests so please tell me if I'm not doing it well.

Before my change, user.liked always returned [] on my project using PG because it did the following request :
SELECT "recommendable_likes".\* FROM "recommendable_likes" WHERE "recommendable_likes"."user_id" = 5 AND "recommendable_likes"."likeable_type" = '--- !ruby/class ''Item''

You can see the likeable_type is not correct here.
Had to change likes.where(:likeable_type => klass) to likes.where(:likeable_type => klass.to_s.classify) in liked_for, disliked_for, etc.

Tests are still passing, and didn't do any new tests cause I don't really now how to test that, seems like the problem does not occur with sqlite3.

Thanks for the awesome gem.
Regards,
