### PR TITLE
Mongoid querier should use "in" since it's receiving an array

### DIFF
--- a/lib/recommendable/helpers/queriers.rb
+++ b/lib/recommendable/helpers/queriers.rb
@@ -11,7 +11,7 @@ module Recommendable
         end
 
         def mongoid(klass, ids)
-          klass.where(:id => ids)
+          klass.where(:id.in => ids)
         end
 
         def mongo_mapper(klass, ids)


### PR DESCRIPTION
The Mongoid querier wasn't working for me. `klass.where(:id => ids)` doesn't actually return anything.  Since `ids` is an array, the querier should be changed to use the `in` Symbol operator, e.g.

``` ruby
klass.where(:id.in => ids)
```

This method is compatible with both Mongoid [2](http://two.mongoid.org/docs/querying/criteria.html#where) and [3](http://mongoid.org/en/origin/docs/selection.html#symbol).

The test suite passes, although I didn't add any new tests since the queriers don't appear to be tested currently.  Please let me know if you'd like to see any revisions to this.
