### PR TITLE
Ratable top method now accepts a start argument

### DIFF
--- a/lib/recommendable/ratable.rb
+++ b/lib/recommendable/ratable.rb
@@ -45,9 +45,14 @@ module Recommendable
           #
           # @param [Fixnum] count the number of items to fetch (defaults to 1)
           # @return [Array] the top items belonging to this class, sorted by score
-          def self.top(count = 1, start = 0)
+          def self.top(options = {})
+            if options.is_a?(Integer)
+              options = { count: options}
+              warn "[DEPRECATION] Recommenable::Ratable.top now takes an options hash. Please call `.top(count: #{options[:count]})` instead of just `.top(#{options[:count]})`"
+            end
+            options.reverse_merge!(count: 1, offset: 0)
             score_set = Recommendable::Helpers::RedisKeyMapper.score_set_for(self)
-            ids = Recommendable.redis.zrevrange(score_set, start, start + count - 1)
+            ids = Recommendable.redis.zrevrange(score_set, options[:offset], options[:offset] + options[:count] - 1)
 
             Recommendable.query(self, ids).sort_by { |item| ids.index(item.id.to_s) }
           end

--- a/test/recommendable/ratable_test.rb
+++ b/test/recommendable/ratable_test.rb
@@ -33,7 +33,7 @@ class RatableTest < MiniTest::Unit::TestCase
     assert @movie.rated?
   end
 
-  def test_top_scope_returns_best_things
+  def test_top_scope_deprecated_syntax_returns_best_things
     @book2 = Factory(:book)
     @book3 = Factory(:book)
     @user = Factory(:user)
@@ -50,6 +50,23 @@ class RatableTest < MiniTest::Unit::TestCase
     assert_equal top[2], @book
   end
 
+  def test_top_scope_returns_best_things
+    @book2 = Factory(:book)
+    @book3 = Factory(:book)
+    @user = Factory(:user)
+    @friend = Factory(:user)
+
+    @user.like(@book2)
+    @friend.like(@book2)
+    @user.like(@book3)
+    @user.dislike(@book)
+
+    top = Book.top(count: 3)
+    assert_equal top[0], @book2
+    assert_equal top[1], @book3
+    assert_equal top[2], @book
+  end
+
   def test_top_scope_returns_best_things_for_ratable_base_class
     @movie2 = Factory(:movie)
     @doc = Factory(:documentary)
@@ -61,7 +78,7 @@ class RatableTest < MiniTest::Unit::TestCase
     @user.like(@movie2)
     @user.dislike(@movie)
 
-    top = Movie.top(3)
+    top = Movie.top(count: 3)
     assert_equal top[0], @doc
     assert_equal top[1], @movie2
     assert_equal top[2], @movie
@@ -78,7 +95,7 @@ class RatableTest < MiniTest::Unit::TestCase
     @user.like(@movie2)
     @user.dislike(@movie)
 
-    top = Movie.top(2, 1)
+    top = Movie.top(count: 2, offset: 1)
     assert_equal top[0], @movie2
     assert_equal top[1], @movie
   end


### PR DESCRIPTION
In order to be able to paginate top elements, I've added a start parameter to the top method on the Ratable module.
The count parameter remains the number of elements you want to get, but the new start parameter allows you to get elements not only starting from 0.

It doesn't change actual behaviour but I guess it can be useful to someone else so here is my pull request.
