### PR TITLE
Fixes for active_record_uuid

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Recommendable.configure do |config|
 end
 ```
 
+Important: in case of `active_record` with id of type `uuid`, use `:active_record_uuid`.
+
 ## Usage
 
 In your model that will be receiving recommendations:


### PR DESCRIPTION
Even though `:active_record_uuid` was available as an ORM config option, it wasn't used in all the places that `ids` were mapped. I've added `ids.map!{ |id| klass.new(id: id).id }.compact` which is the most general option and allows to get correct ids not depending on the `id` or connection adapter type.

I've also added information about `active_record_uuid` ORM to the docummentation. 